### PR TITLE
CSS Transitions

### DIFF
--- a/Maquetado/scss/styles.scss
+++ b/Maquetado/scss/styles.scss
@@ -4,9 +4,11 @@
   font-family: $font-stack;
 
 }
+
 body{
-  padding: 5% 10%;
+  padding: 3% 20%;
 }
+
 .container{
     display: flex;
     flex-direction: row;

--- a/Maquetado/scss/tech.scss
+++ b/Maquetado/scss/tech.scss
@@ -12,20 +12,18 @@
   border-radius: 5px;
   position: relative;
   margin: 10px 20px;
+
   .image {
     width: $tech-logo-size;
-    //margin: 5px auto;
   }
 
   .name {
     font-size: $text-medium;
-    //margin: 5px auto;
   }
 
   .release {
     font-size: $text-small;
     font-weight: bold;
-    //margin: 5px auto;
   }
 
   .description {
@@ -44,6 +42,13 @@
     bottom: 4px;
     right: 4px;
     content: "";
+    transition: 0.5s ease;
   }
+}
 
+.tech:hover{
+  &::before{
+    bottom: -8px;
+    right: -8px;
+  }
 }


### PR DESCRIPTION
## Summary
- Added transition to the before of the tech cards
## Screenshot
HOVER :
BEFORE 
![before](https://user-images.githubusercontent.com/40175251/41490822-2f5b3834-70cc-11e8-8c2f-1d81885c8fd8.png)
AFTER
![after](https://user-images.githubusercontent.com/40175251/41490825-33184fb6-70cc-11e8-812a-d95374067b69.png)

## Trello Card

[https://trello.com/c/tDR63aip/25-css-transitions](url)